### PR TITLE
oj-test 時、 quickrun の :exec を見て実行コマンドを決定する

### DIFF
--- a/README.org
+++ b/README.org
@@ -515,3 +515,4 @@ Below operation flow is recommended.
 - Naoya Yamashita ([[https://github.com/conao3][conao3]])
 
 ** Contributors
+- zk-phi ([[https://github.com/zk-phi][zk-phi]])

--- a/README.org
+++ b/README.org
@@ -216,6 +216,10 @@ If your code pass testcases, get below output in =*oj*= buffer.
   [+] test success: 3 cases
 #+end_src
 
+Compiler command is automatically detected using the =quickrun=
+package. You may use =quickrun-add-command= to add or override
+commands.
+
 ** oj-submit
 =M-x oj-submit= submit your code to online judge.
 (The first time, you need =M-x oj-login= per online judges.)
@@ -272,7 +276,7 @@ If your code pass testcases, get below output in =*oj*= buffer.
 - oj-test-args :: Args for =oj test=.  (default =nil=)
 
   #+begin_src text
-    Args for `oj-test'.
+    Args for `oj-test'. Note that the runtime command (`-c') is detected automatically.
 
     usage: oj test [-h] [-c COMMAND] [-f FORMAT] [-d DIRECTORY] [-m
                    {simple,side-by-side}] [-S] [--no-rstrip]

--- a/oj.el
+++ b/oj.el
@@ -3,7 +3,7 @@
 ;; Copyright (C) 2020  Naoya Yamashita
 
 ;; Author: Naoya Yamashita <conao3@gmail.com>
-;; Version: 1.0.1
+;; Version: 1.0.2
 ;; Keywords: convenience
 ;; Package-Requires: ((emacs "26.1") (quickrun "2.2"))
 ;; URL: https://github.com/conao3/oj.el

--- a/oj.el
+++ b/oj.el
@@ -100,7 +100,9 @@ optional arguments:
   :type '(repeat string))
 
 (defcustom oj-test-args '()
-  "Args for `oj-test'. Note that the runtime command (`-c') is detected automatically.
+  "Args for `oj-test'.
+
+Note that the runtime command (`-c') is detected automatically.
 
 usage: oj test [-h] [-c COMMAND] [-f FORMAT] [-d DIRECTORY] [-m
                {simple,side-by-side}] [-S] [--no-rstrip]

--- a/oj.el
+++ b/oj.el
@@ -99,7 +99,7 @@ optional arguments:
   :group 'oj
   :type '(repeat string))
 
-(defcustom oj-test-args '("-c" "./main.out")
+(defcustom oj-test-args '()
   "Args for `oj-test'.
 
 usage: oj test [-h] [-c COMMAND] [-f FORMAT] [-d DIRECTORY] [-m
@@ -508,14 +508,17 @@ NAME is also whole URL to login."
                  (quickrun--command-key (buffer-file-name))))
          (spec (mapcar (lambda (elm)
                          `(,(string-to-char (substring (car elm) 1)) . ,(cdr elm)))
-                       (quickrun--template-argument alist (buffer-file-name)))))
-    (when-let (fmt (alist-get :compile-only alist))
-      (oj--exec-script (format-spec fmt spec))))
-  (oj--exec-script
-   (concat
-    "oj test"
-    (when oj-test-args
-      (format " %s" (mapconcat #'identity oj-test-args " "))))))
+                       (quickrun--template-argument alist (buffer-file-name))))
+         (exec (or (alist-get :exec alist)
+                   (alist-get :exec quickrun--default-tmpl-alist))))
+    (while (and (consp exec) (cdr exec)) ; has more than two commands
+      (oj--exec-script (format-spec (pop exec) spec)))
+    (oj--exec-script
+     (concat
+      "oj test"
+      (when oj-test-args
+        (format " %s" (mapconcat #'identity oj-test-args " ")))
+      " -c '" (format-spec (if (consp exec) (car exec) exec) spec) "'"))))
 
 (defun oj-submit ()
   "Submit code."

--- a/oj.el
+++ b/oj.el
@@ -100,7 +100,7 @@ optional arguments:
   :type '(repeat string))
 
 (defcustom oj-test-args '()
-  "Args for `oj-test'.
+  "Args for `oj-test'. Note that the runtime command (`-c') is detected automatically.
 
 usage: oj test [-h] [-c COMMAND] [-f FORMAT] [-d DIRECTORY] [-m
                {simple,side-by-side}] [-S] [--no-rstrip]


### PR DESCRIPTION
現状では :compile-only のみ quickrun から引いてきているため、インタプリタ型の言語などでは oj-test-args で実行コマンド (`-c` オプション) を指定する必要があります。またコンパイラの出力ファイル名が `a.out` でない場合も同様に oj-test-args の設定が必要になります。

これは複数の言語を併用している場合などに不便なため、コンパイルコマンドだけでなく実行コマンドまで quickrun の設定から取得してくれると便利かなと思いました。

`c/clang` と `nim` で動作確認しました。