### PR TITLE
コンパイルが失敗するとテストを行わないようにした

### DIFF
--- a/oj.el
+++ b/oj.el
@@ -545,11 +545,10 @@ NAME is also whole URL to login."
       #'oj--join-scripts
       (append
        (when (consp exec)
-         (nreverse
-          (mapcar
-           (lambda (arg)
-             (format-spec arg spec))
-           (cdr (reverse exec)))))
+         (mapcar
+          (lambda (arg)
+            (format-spec arg spec))
+          (nreverse (cdr (reverse exec)))))
        (list
         (concat
          "oj test"

--- a/oj.el
+++ b/oj.el
@@ -288,6 +288,10 @@ NOTE: online-judge symbol MUST NOT include slash (\"/\").")
     (with-current-buffer oj-buffer
       (comint-send-input))))
 
+(defun oj--exec-script-multiple (&rest scripts)
+  "Exec all SCRIPTS joined by \" && \" in `oj-buffer'."
+  (oj--exec-script (string-join scripts " && ")))
+
 (defun oj--file-readable (file)
   "Return FILE if readable."
   (when (file-readable-p file) file))

--- a/oj.el
+++ b/oj.el
@@ -288,9 +288,9 @@ NOTE: online-judge symbol MUST NOT include slash (\"/\").")
     (with-current-buffer oj-buffer
       (comint-send-input))))
 
-(defun oj--exec-script-multiple (&rest scripts)
-  "Exec all SCRIPTS joined by \" && \" in `oj-buffer'."
-  (oj--exec-script (string-join scripts " && ")))
+(defun oj--join-scripts (&rest scripts)
+  "Join all SCRIPTS with \" && \"."
+   (string-join scripts " && "))
 
 (defun oj--file-readable (file)
   "Return FILE if readable."
@@ -540,21 +540,22 @@ NAME is also whole URL to login."
                        (quickrun--template-argument alist (buffer-file-name))))
          (exec (or (alist-get :exec alist)
                    (alist-get :exec quickrun--default-tmpl-alist))))
-    (apply
-     #'oj--exec-script-multiple
-     (append
-      (when (consp exec)
-        (nreverse
-         (mapcar
-          (lambda (arg)
-            (format-spec arg spec))
-          (cdr (reverse exec)))))
-      (list
-       (concat
-        "oj test"
-        (when oj-test-args
-          (format " %s" (mapconcat #'identity oj-test-args " ")))
-        " -c '" (format-spec (if (consp exec) (car (last exec)) exec) spec) "'"))))))
+    (oj--exec-script
+     (apply
+      #'oj--join-scripts
+      (append
+       (when (consp exec)
+         (nreverse
+          (mapcar
+           (lambda (arg)
+             (format-spec arg spec))
+           (cdr (reverse exec)))))
+       (list
+        (concat
+         "oj test"
+         (when oj-test-args
+           (format " %s" (mapconcat #'identity oj-test-args " ")))
+         " -c '" (format-spec (if (consp exec) (car (last exec)) exec) spec) "'")))))))
 
 ;;;###autoload
 (defun oj-submit ()

--- a/oj.el
+++ b/oj.el
@@ -540,14 +540,21 @@ NAME is also whole URL to login."
                        (quickrun--template-argument alist (buffer-file-name))))
          (exec (or (alist-get :exec alist)
                    (alist-get :exec quickrun--default-tmpl-alist))))
-    (while (and (consp exec) (cdr exec)) ; has more than two commands
-      (oj--exec-script (format-spec (pop exec) spec)))
-    (oj--exec-script
-     (concat
-      "oj test"
-      (when oj-test-args
-        (format " %s" (mapconcat #'identity oj-test-args " ")))
-      " -c '" (format-spec (if (consp exec) (car exec) exec) spec) "'"))))
+    (apply
+     #'oj--exec-script-multiple
+     (append
+      (when (consp exec)
+        (nreverse
+         (mapcar
+          (lambda (arg)
+            (format-spec arg spec))
+          (cdr (reverse exec)))))
+      (list
+       (concat
+        "oj test"
+        (when oj-test-args
+          (format " %s" (mapconcat #'identity oj-test-args " ")))
+        " -c '" (format-spec (if (consp exec) (car (last exec)) exec) spec) "'"))))))
 
 ;;;###autoload
 (defun oj-submit ()


### PR DESCRIPTION
現状、C++などでコンパイルに失敗した場合もテストを行うため、コンパイルエラーがテストで流されてしまい、そもそもコンパイルに失敗したことに気付かないという問題がありました。
これを解決するため、` && `で結合して実行する`oj--exec-script-multiple`を導入し、`oj-test`においてコンパイル部と`oj test`をその関数に通して実行するようにしました。
これにより、コンパイルが失敗した場合はテストが行われなくなりました。

`reverse`や`last`を使っているため、`exec`のサイズが大きい場合は実行速度に不安がありますが、実行手順の量がそこまで大きくなることはないだろうと考えています。

動作確認はC++で行いました。インタプリタ型の言語でも確認したほうがよいかもしれません。